### PR TITLE
Added httpretty fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pytest-httpretty - A thin wrapper of HTTPretty for pytest
 
-pytest-httpretty provides `httpretty` marker and `stub_get()` shorthand function.
+pytest-httpretty provides `httpretty` marker, fixture and `stub_get()` shorthand function.
 
 ```python
 import httpretty
@@ -21,4 +21,9 @@ def test_stub_get():
     stub_get('http://example.com/', body='World!')
 
     assert requests.get('http://example.com').text == 'World!'
+
+
+@pytest.fixture
+def dummy(httpretty):
+    httpretty.register_uri(httpretty.GET, 'http://example.com/', body='Hello')
 ```

--- a/pytest_httpretty.py
+++ b/pytest_httpretty.py
@@ -1,6 +1,7 @@
 import functools
 
-import httpretty
+import pytest
+import httpretty as _httpretty
 
 
 __version__ = '0.2.0'
@@ -14,16 +15,30 @@ def pytest_configure(config):
 def pytest_runtest_setup(item):
     marker = item.get_marker('httpretty')
     if marker is not None:
-        httpretty.reset()
-        httpretty.enable()
+        _httpretty.reset()
+        _httpretty.enable()
 
 
 def pytest_runtest_teardown(item, nextitem):
     marker = item.get_marker('httpretty')
     if marker is not None:
-        httpretty.disable()
+        _httpretty.disable()
 
 
-stub_get = functools.partial(httpretty.register_uri, httpretty.GET)
+@pytest.fixture
+def httpretty():
+    """
+    A thin wrapper of httpretty which enables httpretty during setup
+    and disables it while tearing down.
+    """
+    _httpretty.reset()
+    _httpretty.enable()
 
-last_request = httpretty.last_request
+    yield _httpretty
+
+    _httpretty.disable()
+
+
+stub_get = functools.partial(_httpretty.register_uri, _httpretty.GET)
+
+last_request = _httpretty.last_request

--- a/test_pytest_httpretty.py
+++ b/test_pytest_httpretty.py
@@ -41,3 +41,9 @@ def test_stub_get(dummy):
     stub_get('http://example.com/', body='World!')
 
     assert requests.get('http://example.com').text == 'World!'
+
+
+def test_httpretty_fixture(httpretty):
+    httpretty.register_uri(httpretty.GET, 'http://example.com/', body='Hello')
+
+    assert requests.get('http://example.com').text == 'Hello'


### PR DESCRIPTION
Markers cannot be used in fixtures itself so for better re-usability of fixtures depending on httpretty adding httpretty fixture