### PR TITLE
use `get_closest_marker` instead of `get_marker`

### DIFF
--- a/pytest_httpretty.py
+++ b/pytest_httpretty.py
@@ -12,14 +12,14 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    marker = item.get_marker('httpretty')
+    marker = item.get_closest_marker('httpretty')
     if marker is not None:
         httpretty.reset()
         httpretty.enable()
 
 
 def pytest_runtest_teardown(item, nextitem):
-    marker = item.get_marker('httpretty')
+    marker = item.get_closest_marker('httpretty')
     if marker is not None:
         httpretty.disable()
 

--- a/pytest_httpretty.py
+++ b/pytest_httpretty.py
@@ -1,9 +1,21 @@
+from distutils.version import LooseVersion
 import functools
 
 import httpretty
-
+import pytest
 
 __version__ = '0.2.0'
+
+
+def get_marker_method(item):
+    _marker_method = None
+    pytest_version = LooseVersion("{}".format(pytest.__version__))
+    if pytest_version < LooseVersion("4.1.0"):
+        _marker_method = item.get_marker('httpretty')
+    else:
+        _marker_method = item.get_closest_marker('httpretty')
+
+    return _marker_method
 
 
 def pytest_configure(config):
@@ -12,14 +24,14 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    marker = item.get_closest_marker('httpretty')
+    marker = get_marker_method(item)
     if marker is not None:
         httpretty.reset()
         httpretty.enable()
 
 
 def pytest_runtest_teardown(item, nextitem):
-    marker = item.get_closest_marker('httpretty')
+    marker = get_marker_method(item)
     if marker is not None:
         httpretty.disable()
 


### PR DESCRIPTION
In the latest version of pytest was removed the `get_marker` method . 

#4546: Remove Node.get_marker(name) the return value was not usable for more than a existence check.

Use Node.get_closest_marker(name) as a replacement.
Link to the pytest changelog : https://docs.pytest.org/en/latest/changelog.html
