### PR TITLE
Node.get_marker not available anymore

### DIFF
--- a/pytest_httpretty.py
+++ b/pytest_httpretty.py
@@ -12,14 +12,14 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    marker = item.get_marker('httpretty')
+    marker = item.get_closest_marker('httpretty')
     if marker is not None:
         httpretty.reset()
         httpretty.enable()
 
 
 def pytest_runtest_teardown(item, nextitem):
-    marker = item.get_marker('httpretty')
+    marker = item.get_closest_marker('httpretty')
     if marker is not None:
         httpretty.disable()
 


### PR DESCRIPTION
https://docs.pytest.org/en/latest/historical-notes.html#update-marker-code

A compatible function has been introduced, and allows tests to run fine.

python 2.7
pytest                        4.5.0
pytest-cov                    2.7.1
pytest-httpretty              0.2.0
pytest-remotedata             0.3.1

all unit tests fails on 
```
item = <Function test_get_kcmd>, nextitem = <Function test_check_conn>

    def pytest_runtest_teardown(item, nextitem):
>       marker = item.get_marker('httpretty')
E       AttributeError: 'Function' object has no attribute 'get_marker'

/usr/local/lib/python2.7/site-packages/pytest_httpretty.py:22: AttributeError
```